### PR TITLE
Add Slice slider for cross-section view of models

### DIFF
--- a/src/components/Lambda360View.tsx
+++ b/src/components/Lambda360View.tsx
@@ -40,11 +40,13 @@ function GlbScene({
 	edgeColor,
 	showEdges,
 	edgePositions,
+	clipPlane,
 }: {
 	scene: THREE.Group;
 	edgeColor: string;
 	showEdges: boolean;
 	edgePositions: Float32Array | null;
+	clipPlane: THREE.Plane;
 }) {
 	const edgeLineRef = useRef<THREE.LineSegments | null>(null);
 
@@ -52,7 +54,11 @@ function GlbScene({
 		if (!edgePositions) return;
 		const geometry = new THREE.BufferGeometry();
 		geometry.setAttribute('position', new THREE.BufferAttribute(edgePositions, 3));
-		const material = new THREE.LineBasicMaterial({ color: edgeColor, linewidth: 1 });
+		const material = new THREE.LineBasicMaterial({
+			color: edgeColor,
+			linewidth: 1,
+			clippingPlanes: [clipPlane],
+		});
 		const lineSegments = new THREE.LineSegments(geometry, material);
 		lineSegments.userData._isEdge = true;
 		scene.add(lineSegments);
@@ -64,7 +70,7 @@ function GlbScene({
 			material.dispose();
 			edgeLineRef.current = null;
 		};
-	}, [scene, edgePositions]);
+	}, [scene, edgePositions, clipPlane]);
 
 	useEffect(() => {
 		if (edgeLineRef.current) {
@@ -85,9 +91,11 @@ function GlbScene({
 				mat.polygonOffset = true;
 				mat.polygonOffsetFactor = 1;
 				mat.polygonOffsetUnits = 1;
+				mat.clippingPlanes = [clipPlane];
+				mat.clipShadows = true;
 			}
 		});
-	}, [scene]);
+	}, [scene, clipPlane]);
 
 	return <primitive object={scene} />;
 }
@@ -109,6 +117,8 @@ interface SceneManagerProps {
 	showGrid: boolean;
 	viewRequest: { type: ViewType; ts: number } | null;
 	orthographic: boolean;
+	clipNear: number;
+	clipPlane: THREE.Plane;
 }
 
 function SceneManager({
@@ -123,6 +133,8 @@ function SceneManager({
 	showGrid,
 	viewRequest,
 	orthographic,
+	clipNear,
+	clipPlane,
 }: SceneManagerProps) {
 	const [items, setItems] = useState<LoadedItem[]>([]);
 	const prevItemsRef = useRef<LoadedItem[]>([]);
@@ -233,7 +245,7 @@ function SceneManager({
 
 	return (
 		<>
-			<OrbitSizeControls maxSize={maxSize} orthographic={orthographic} viewRequest={viewRequest} />
+			<OrbitSizeControls maxSize={maxSize} orthographic={orthographic} viewRequest={viewRequest} clipNear={clipNear} clipPlane={clipPlane} />
 
 			<ambientLight intensity={0.6} />
 			<directionalLight position={[10, 10, 5]} intensity={0.8} />
@@ -248,6 +260,7 @@ function SceneManager({
 							edgeColor={edgeColor}
 							showEdges={showEdges}
 							edgePositions={item.edgePositions}
+							clipPlane={clipPlane}
 						/>
 					))}
 					{annotations && <Annotations annotations={annotations} />}
@@ -289,6 +302,9 @@ export default function Lambda360View({
 	const [showAxis, setShowAxis] = useState(true);
 	const [showGrid, setShowGrid] = useState(false);
 	const [viewRequest, setViewRequest] = useState<{ type: ViewType; ts: number } | null>(null);
+	const [clipNear, setClipNear] = useState(0);
+	// model 用クリッピング平面。OrbitSizeControls の useFrame で毎フレーム更新する。
+	const clipPlane = useMemo(() => new THREE.Plane(new THREE.Vector3(0, 0, -1), 0), []);
 
 	const handleViewChange = (view: ViewType) => {
 		setViewRequest({ type: view, ts: Date.now() });
@@ -330,6 +346,8 @@ export default function Lambda360View({
 					showGrid={showGrid}
 					onToggleGrid={() => setShowGrid(!showGrid)}
 					onDownloadStep={onDownloadStep}
+					clipNear={clipNear}
+					onClipNearChange={setClipNear}
 				/>
 			)}
 			{/* Canvas */}
@@ -338,6 +356,7 @@ export default function Lambda360View({
 					antialias: true,
 					toneMapping: THREE.NoToneMapping,
 				}}
+				onCreated={({ gl }) => { gl.localClippingEnabled = true; }}
 				style={{ background: backgroundColor }}
 			>
 				<SceneManager
@@ -352,6 +371,8 @@ export default function Lambda360View({
 					showGrid={showGrid}
 					viewRequest={viewRequest}
 					orthographic={orthographic}
+					clipNear={clipNear}
+					clipPlane={clipPlane}
 				/>
 			</Canvas>
 			{/* nodeFooter */}

--- a/src/components/OrbitSizeControls.tsx
+++ b/src/components/OrbitSizeControls.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import { useThree } from '@react-three/fiber';
+import { useEffect, useRef, useMemo } from 'react';
+import { useThree, useFrame } from '@react-three/fiber';
 import { OrbitControls, PerspectiveCamera, OrthographicCamera } from '@react-three/drei';
 import * as THREE from 'three';
 import type { ViewType } from './ViewMenu';
@@ -10,6 +10,8 @@ interface OrbitSizeControlsProps {
 	maxSize: number;
 	orthographic: boolean;
 	viewRequest: { type: ViewType; ts: number } | null;
+	clipNear: number;
+	clipPlane: THREE.Plane;
 }
 
 /**
@@ -23,7 +25,7 @@ interface OrbitSizeControlsProps {
  * - maxSize変化時（モデルスワップ）: カメラ方向を保ったまま距離をスケール
  * - viewRequest変化時: 指定ビューにカメラを移動
  */
-export function OrbitSizeControls({ maxSize, orthographic, viewRequest }: OrbitSizeControlsProps) {
+export function OrbitSizeControls({ maxSize, orthographic, viewRequest, clipNear, clipPlane }: OrbitSizeControlsProps) {
 	const { camera, size } = useThree();
 	const controls = useThree(state => state.controls);
 	const prevCameraRef = useRef<THREE.Camera | null>(null);
@@ -71,6 +73,23 @@ export function OrbitSizeControls({ maxSize, orthographic, viewRequest }: OrbitS
 		};
 
 	}, [viewRequest, maxSize, controls, camera]);
+
+	// clipNear: 0=全体表示 / 0.5=中央断面 / 1=完全クリップ。
+	// カメラからターゲット方向を法線とする平面を、カメラから clipDist の位置に置く。
+	// material.clippingPlanes で参照されるので、Grid/Annotation/Axes は影響を受けず model のみがクリップされる。
+	// 1.5倍はバウンディングボックス対角（最大 √3/2*maxSize ≒ 0.87*maxSize）を確実にカバーするマージン。
+	const tmpNormal = useMemo(() => new THREE.Vector3(), []);
+	const tmpCoplanar = useMemo(() => new THREE.Vector3(), []);
+	useFrame(() => {
+		if (!controls) return;
+		const target = (controls as unknown as { target: THREE.Vector3 }).target;
+		const D = camera.position.distanceTo(target);
+		const clipDist = D + (clipNear * 2 - 1) * maxSize * 1.5;
+
+		tmpNormal.subVectors(target, camera.position).normalize();
+		tmpCoplanar.copy(camera.position).addScaledVector(tmpNormal, clipDist);
+		clipPlane.setFromNormalAndCoplanarPoint(tmpNormal, tmpCoplanar);
+	});
 
 	return (
 		<>

--- a/src/components/ViewMenu.tsx
+++ b/src/components/ViewMenu.tsx
@@ -23,6 +23,8 @@ interface ViewMenuProps {
 	showGridButton?: boolean;
 	showGrid?: boolean;
 	onDownloadStep?: () => void;
+	clipNear?: number;
+	onClipNearChange?: (value: number) => void;
 }
 
 export function ViewMenu({
@@ -34,6 +36,8 @@ export function ViewMenu({
 	showGridButton = true,
 	showGrid = true,
 	onDownloadStep,
+	clipNear,
+	onClipNearChange,
 }: ViewMenuProps) {
 	const buttonStyle: React.CSSProperties = {
 		display: 'flex',
@@ -135,6 +139,36 @@ export function ViewMenu({
 					{icon}
 				</button>
 			))}
+
+			{/* 断面スライダー */}
+			{onClipNearChange && (
+				<>
+					<Separator />
+					<label
+						title="Slice"
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 6,
+							fontSize: 12,
+							fontFamily: 'sans-serif',
+							color: '#444',
+							paddingInline: 4,
+						}}
+					>
+						Slice
+						<input
+							type="range"
+							min={0}
+							max={1}
+							step={0.01}
+							value={clipNear ?? 0}
+							onChange={(e) => onClipNearChange(parseFloat(e.target.value))}
+							style={{ width: 80 }}
+						/>
+					</label>
+				</>
+			)}
 
 			{/* STEPダウンロード */}
 			{onDownloadStep && (


### PR DESCRIPTION
## Summary
- Adds a `Slice` slider in the `ViewMenu` that lets users see inside the model
- Slider value `t ∈ [0, 1]`: `0` = full model visible, `0.5` = mid cross-section, `1` = fully clipped
- Implemented via `material.clippingPlanes` so only model meshes and edges are clipped — Grid, Axes, and Annotations are unaffected
- The clipping plane normal points along the camera→target direction and updates every frame via `useFrame`, so the cross-section always stays perpendicular to the current view
- Clip distance is `D + (t*2 - 1) * maxSize * 1.5` where `D` is the camera-to-target distance; the 1.5x margin guarantees full coverage of the bounding box diagonal

## Test plan
- [ ] Open a model and confirm Slice slider at 0 shows full model
- [ ] Drag slider to 0.5 and confirm a cross-section appears at the model center
- [ ] Drag slider to 1 and confirm the model disappears entirely
- [ ] Orbit camera with slider at 0.5 and confirm the cross-section follows the view
- [ ] Confirm Grid, Axes, and Annotations remain visible at all slider values